### PR TITLE
Added BitwiseXOR resolution, works for simple variables containing 'string ^ string' ; changed debug output, now it prints to STDERR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This Project is tied to nikic/php-parser version 2.0 series, and so tied to PHP 7.4
+
 # An aid to de-obfuscating PHP malware
 
 Lots of malware that afflicts WordPress, Joomla and other PHP-based

--- a/RevPHPNodeVisitor.php
+++ b/RevPHPNodeVisitor.php
@@ -43,6 +43,7 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 			'base64_decode', 'gzuncompress', 'strrev', 'gzinflate',
 			'str_rot13', 'urldecode', 'chr', 'ord', 'strtolower',
 			'strtoupper', 'base64_encode', 'range', 'implode',
+			'bzdecompress',
 		);
 		foreach ($special_functions as $fname) {
 			$this->decode_func_names[] = strtolower($fname);

--- a/RevPHPNodeVisitor.php
+++ b/RevPHPNodeVisitor.php
@@ -171,6 +171,12 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 			} else {
 			}
 		} else
+		if ($node instanceof PhpParser\Node\Expr\BinaryOp\BitwiseXor) {
+			if ($this->xorStrings($node, $value)) {
+				$found_value = TRUE;
+			} else {
+			}
+		} else
 		if ($node instanceof PhpParser\Node\Expr\Variable) {
 			$variable_value = null;
 			if ($node->name instanceof PhpParser\Node)
@@ -276,6 +282,10 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 			if ($this->concatStrings($node, $varname))
 				$found_string = TRUE;
 		} else
+		if ($node instanceof PhpParser\Node\Expr\BinaryOp\BitwiseXor) {
+			if ($this->xorStrings($node, $varname))
+				$found_string = TRUE;
+		} else
 		if ($node instanceof PhpParser\Node\Scalar\String_) {
 			$varname = $node->value; # XXX - ???
 			$found_string = TRUE;
@@ -317,7 +327,7 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 				$varname = $node->name;
 				$found_string = TRUE;
 			} else {
-				debug_print_backtrace();
+				ob_start(); debug_print_backtrace(); fwrite(STDERR, rtrim(ob_get_clean() ?: "failed to dump backtrace") . PHP_EOL);
 			}
 		} else
 		if ($node instanceof PhpParser\Node\Expr\List_) {
@@ -334,7 +344,7 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 				# Something dreadfully wrong. This is pretty much the
 				# very last thing it could be.
 				fwrite(STDERR, "Problem in findName(), no name, line {$node->getLine()}: ".print_r($node, TRUE)."\n");
-				debug_print_backtrace();
+				ob_start(); debug_print_backtrace(); fwrite(STDERR, rtrim(ob_get_clean() ?: "failed to dump backtrace") . PHP_EOL);
 			}
 		}
 		#fwrite(STDERR, "leave findName, {$node->getType()}, name: \"$varname\"\n");
@@ -388,6 +398,26 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 			if ($this->findValue($concat->right, $rightvalue)) {
 				if (is_string($rightvalue))
 					$concat->right = $this->newNodeAsType($rightvalue, false);
+			}
+		}
+		return $found_string;
+	}
+
+	public function xorStrings(PhpParser\Node\Expr\BinaryOp\BitwiseXor $xorstring, &$xoredstring) {
+		$found_string = FALSE;
+		if ($this->findValue($xorstring->left, $leftstring)
+			&& $this->findValue($xorstring->right, $rightstring)) {
+			$xoredstring = $leftstring ^ $rightstring;
+			$found_string = TRUE;
+		} else {
+			# Replace left or right nodes with statically-determinable values, if possible
+			if ($this->findValue($xorstring->left, $leftvalue)) {
+				if (is_string($leftvalue))
+					$xorstring->left = $this->newNodeAsType($leftvalue, false);
+			}
+			if ($this->findValue($xorstring->right, $rightvalue)) {
+				if (is_string($rightvalue))
+					$xorstring->right = $this->newNodeAsType($rightvalue, false);
 			}
 		}
 		return $found_string;
@@ -814,6 +844,31 @@ class RevPHPNodeVisitor extends PhpParser\NodeVisitorAbstract
 						if ($this->findValue($node->left->right, $othervalue)) {
 							if (is_string($othervalue)) {
 								$node->right = $this->newNodeAsType($othervalue.$rightvalue);
+								$node->left  = $node->left->left;
+							}
+						}
+					} else {
+						$node->right = $this->newNodeAsType($rightvalue, false);
+					}
+				}
+			} else {
+				if ($left_is_string)
+					$node->left = $this->newNodeAsType($leftvalue, false);
+			}
+		} else
+		if ($node instanceof PhpParser\Node\Expr\BinaryOp\BitwiseXor) {
+			# Roll up any substrings. This can be computationally inefficient.
+			$left_is_string = false;
+			if ($this->findValue($node->left, $leftvalue)) {
+				if (is_string($leftvalue))
+					$left_is_string = true;
+			}
+			if ($this->findValue($node->right, $rightvalue)) {
+				if (is_string($rightvalue)) {
+					if ($node->left instanceof PhpParser\Node\Expr\BinaryOp\BitwiseXor) {
+						if ($this->findValue($node->left->right, $othervalue)) {
+							if (is_string($othervalue)) {
+								$node->right = $this->newNodeAsType($othervalue ^ $rightvalue);
 								$node->left  = $node->left->left;
 							}
 						}

--- a/SymbolTable.php
+++ b/SymbolTable.php
@@ -115,11 +115,11 @@ public function isSymbol($candidate_string) {
 public function globalSymbolValue($name, &$value) {
 	$found_value = FALSE;
 	if (is_object($name)) {
-		debug_print_backtrace();
+		ob_start(); debug_print_backtrace(); fwrite(STDERR, rtrim(ob_get_clean() ?: "failed to dump backtrace") . PHP_EOL);
 	}
 	#fwrite(STDERR, "+++++\nglobalSymbolValue: ".print_r($name, TRUE)."\n-------\n");
 	if (!is_string($name) && !is_int($name)) {
-		debug_print_backtrace();
+		ob_start(); debug_print_backtrace(); fwrite(STDERR, rtrim(ob_get_clean() ?: "failed to dump backtrace") . PHP_EOL);
 		fwrite(STDERR, "Bad array name in globalSymbolValue:\n");
 		fwrite(STDERR, print_r($name, true));
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,21 @@
 {
+    "name": "gnanet/reverse-php-malware",
+    "description": "De-obfuscate and reverse engineer PHP malware, originalproject: https://github.com/bediger4000/reverse-php-malware",
+    "homepage": "https://github.com/gnanet/reverse-php-malware",
+    "type": "project",
+    "authors": [
+        {
+            "name": "Bruce Ediger",
+            "email": "bediger8@gmail.com"
+        },
+        {
+            "name": "GNa",
+            "email": "gna@r-us.hu"
+        }
+    ],
+    "minimum-stability": "stable",
     "require": {
+        "php": "^7.4",
         "nikic/php-parser": "^2.0"
     }
 }

--- a/revphp
+++ b/revphp
@@ -6,7 +6,7 @@ include('SymbolTable.php');
 include('RevPHPNodeVisitor.php');
 
 use PhpParser\NodeTraverser;
-use PhpParser\ParserFactor;
+use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter;
 
 $remove_comments = true;


### PR DESCRIPTION
TODO: handle goto statement and clean-up the order of statements, and variable assigments. That would allow further deobfuscation, that fails otherwise.

@bediger4000  this pull request solves a small part of issue #2  the XOR of strings