### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:7.4-cli-buster
+
+RUN apt-get update && apt-get install -y git
+
+RUN curl -s https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+COPY . /app
+WORKDIR /app
+
+RUN composer install
+
+ENTRYPOINT [ "./revphp" ]


### PR DESCRIPTION
Add Dockerfile for the convenience.
I think using Docker is the most clean & easy way to use the tool without a manual setup.

## Usage

```
$ docker build -t reverse_php_malware .
$ docker container run -it --rm --volume=/tmp:/tmp reverse_php_malware /tmp/path/to/file.php 
```